### PR TITLE
FIX: Unit Tests on Windows

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots install -DjacocoAgg
       - name: Run pre-commit tests
-        run: pre-commit run --all-files --verbose
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files --verbose
       - name: Test with Maven
         if: (matrix.java-version == 8)
         run: mvn --batch-mode verify -DjacocoAgg

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -23,6 +23,8 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots install -DjacocoAgg
+      - name: Run pre-commit tests
+        run: pre-commit run --all-files --verbose
       - name: Test with Maven
         if: (matrix.java-version == 8)
         run: mvn --batch-mode verify -DjacocoAgg

--- a/src/test/java/org/openpreservation/odf/fmt/FormatSnifferTest.java
+++ b/src/test/java/org/openpreservation/odf/fmt/FormatSnifferTest.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class FormatSnifferTest {
     @Test
-    public void testSniffXMLString() throws IOException {
+    public void testSniffXMLString() throws IOException, URISyntaxException {
         URL empty = ClassLoader.getSystemResource(TestFiles.EMPTY_FODS);
-        Formats fmt = FormatSniffer.sniff(empty.getPath());
+        Formats fmt = FormatSniffer.sniff(new File(empty.toURI()).getAbsolutePath());
         assertEquals(String.format("%s SHOULD sniff as format %s, not %s.", TestFiles.EMPTY_FODS, Formats.XML, fmt),
                 Formats.XML, fmt);
     }
@@ -143,9 +143,9 @@ public class FormatSnifferTest {
     }
 
     @Test
-    public void testSniffEncodingString() throws IOException {
+    public void testSniffEncodingString() throws IOException, URISyntaxException {
         URL empty = ClassLoader.getSystemResource(TestFiles.EMPTY_FODS);
-        Encodings enc = FormatSniffer.sniffEncoding(empty.getPath());
+        Encodings enc = FormatSniffer.sniffEncoding(new File(empty.toURI()).getAbsolutePath());
         assertEquals(String.format("%s HAS encoding %s, not %s.", TestFiles.EMPTY_FODS, Encodings.NONE, enc),
                 Encodings.NONE, enc);
     }

--- a/src/test/java/org/openpreservation/odf/fmt/OdfFormatsTest.java
+++ b/src/test/java/org/openpreservation/odf/fmt/OdfFormatsTest.java
@@ -85,9 +85,10 @@ public class OdfFormatsTest {
     }
 
     @Test
-    public void testIsPackageString() throws IOException {
+    public void testIsPackageString() throws IOException, URISyntaxException {
         URL empty = ClassLoader.getSystemResource(TestFiles.EMPTY_ODS);
-        assertTrue(String.format("%s IS a package.", TestFiles.EMPTY_ODS), OdfFormats.isPackage(empty.getPath()));
+        assertTrue(String.format("%s IS a package.", TestFiles.EMPTY_ODS),
+                OdfFormats.isPackage(new File(empty.toURI()).getAbsolutePath()));
     }
 
     @Test
@@ -101,10 +102,10 @@ public class OdfFormatsTest {
     }
 
     @Test
-    public void testIsPackageStringNoMime() throws IOException {
+    public void testIsPackageStringNoMime() throws IOException, URISyntaxException {
         URL empty = ClassLoader.getSystemResource(TestFiles.NO_MIME_ODS);
         assertFalse(String.format("%s IS NOT a package.", TestFiles.NO_MIME_ODS),
-                OdfFormats.isPackage(empty.getPath()));
+                OdfFormats.isPackage(new File(empty.toURI()).getAbsolutePath()));
     }
 
     @Test
@@ -191,9 +192,10 @@ public class OdfFormatsTest {
     }
 
     @Test
-    public void testIsXMLString() throws IOException {
+    public void testIsXMLString() throws IOException, URISyntaxException {
         URL empty = ClassLoader.getSystemResource(TestFiles.EMPTY_FODS);
-        assertTrue(String.format("%s IS a flat XML file.", TestFiles.EMPTY_FODS), OdfFormats.isXml(empty.getPath()));
+        assertTrue(String.format("%s IS a flat XML file.", TestFiles.EMPTY_FODS),
+                OdfFormats.isXml(new File(empty.toURI()).getAbsolutePath()));
     }
 
     @Test


### PR DESCRIPTION
- use path generated from `File` objects rather than URL; and
- run pre-commits as part of GH workflow.